### PR TITLE
🔖 Bump version to 2.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 1.0.0
+current_version = 2.0.0
 
 [bumpversion:file:setup.cfg]
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Django REST Framework JSON Schema support
 =========================================
 
-:Version: 1.0.0
+:Version: 2.0.0
 :Source: https://github.com/maykinmedia/drf-jsonschema-serializer
 :Keywords: django, rest, jsonschema
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+2.0.0 (2023-07-11)
+==================
+
+No changes in functionality or public API, just our supported versions of Python/Django:
+
+* Dropped support for end-of-life Django 4.0.x
+* Confirmed support for Python 3.11
+* Confirmed support for Django 4.2
+
 1.0.0 (2023-02-14)
 ==================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testapp.settings")
 project = "drf-jsonschema-serializer"
 copyright = "2023, Maykin Media"
 author = "Maykin Media"
-release = "1.0.0"
+release = "2.0.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # see http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = drf-jsonschema-serializer
-version = 1.0.0
+version = 2.0.0
 description = JSON Schema support for Django REST Framework
 long_description = file: README.rst
 url = https://github.com/maykinmedia/drf-jsonschema-serializer


### PR DESCRIPTION
No functionality or changes in our API, but it drops support for
Django 4.0
